### PR TITLE
Replaced duplicate code in gametime

### DIFF
--- a/TombRaiderII.asl
+++ b/TombRaiderII.asl
@@ -1,7 +1,8 @@
 // Universal Tomb Raider II Autosplitter for Livesplit
 // Author: FluxMonkii (derivative works of Supergamer57)
+// Contributor: MidgeOnTwitch
 // Support: https://discord.gg/UPawKth (Tomb Runner Discord Server)
-// Version 1.2
+// Version 1.3
 
 // Adapts to all commonly used Tomb Raider II executables including; 
 // Multipatch, Eidos Premier Collection, Eidos UK Box, German, Soul and Japanese releases
@@ -34,6 +35,8 @@ state("tomb2", "Japanese") {
 
 init {
 	uint validity = 0;
+    vars.game_ver = 0;  // 1 for Soul's, 2 for JP
+
 	byte[] multipatch = new byte[] {0xE3, 0xA8, 0x8E};
 	byte[] epc = new byte[] {0x03, 0xC4, 0x8F};
 	byte[] ukbox = new byte[] {0x7F, 0x76, 0x6A};
@@ -43,52 +46,54 @@ init {
 
 	byte[] executable = memory.ReadBytes(modules.First().BaseAddress + 0x88, 3);
 	
-	for (int i = 0; i < executable.Length; i++){
+	for (int i = 0; i < executable.Length; i++) {
       if (executable[i] == multipatch[i]) validity++; 
     }
-	if(validity == 3){
+	if(validity == 3) {
 		version = "Multipatch";
-	}
-	validity = 0;
+    }
+    validity = 0;
 	
-	for (int i = 0; i < executable.Length; i++){
+	for (int i = 0; i < executable.Length; i++) {
       if (executable[i] == epc[i]) validity++; 
     }
-	if(validity == 3){
+	if(validity == 3) {
 		version = "Eidos Premier Collection";
-	}
-	validity = 0;
+    }
+    validity = 0;
 	
-	for (int i = 0; i < executable.Length; i++){
+	for (int i = 0; i < executable.Length; i++) {
       if (executable[i] == ukbox[i]) validity++; 
     }
-	if(validity == 3){
+    if(validity == 3) {
 		version = "Eidos UK Box";
-	}
-	validity = 0;
+    }
+    validity = 0;
 	
-	for (int i = 0; i < executable.Length; i++){
+	for (int i = 0; i < executable.Length; i++) {
       if (executable[i] == german[i]) validity++; 
     }
-	if(validity == 3){
+	if(validity == 3) {
 		version = "German";
-	}
+    }
 	validity = 0;
 	
-	for (int i = 0; i < executable.Length; i++){
+	for (int i = 0; i < executable.Length; i++) {
 		if (executable[i] == soul[i]) validity++; 
     }
-	if(validity == 3){
-		version = "Soul";
-	}
+	if(validity == 3) {
+		vars.game_ver = 1;
+        version = "Soul";
+    }
 	validity = 0;
 	
-	for (int i = 0; i < executable.Length; i++){
+	for (int i = 0; i < executable.Length; i++) {
 		if (executable[i] == jpn[i]) validity++; 
     }
-	if(validity == 3){
+	if(validity == 3) {
+        vars.game_ver = 2;
 		version = "Japanese";
-	}
+    }
 	validity = 0;
 }
 
@@ -108,33 +113,20 @@ gameTime {
 	var acc = 0;
 	var lvl = 18;
 	
-	var levelStats = (IntPtr)(0x51E9F8);
+	var levelStats = (IntPtr)(0x51E9F8);  // Correct for game_ver == 0
 	
-	uint validity = 0;
-	byte[] soul = new byte[] {0x70, 0x7C, 0x6A};
-	byte[] jpn = new byte[] {0x6F, 0xB6, 0xA3};
-	byte[] executable = memory.ReadBytes(modules.First().BaseAddress + 0x88, 3);
-	for (int i = 0; i < executable.Length; i++){
-      if (executable[i] == soul[i]) validity++; 
+	if(vars.game_ver == 1) {
+		levelStats = (IntPtr)(0x51EA18);  // Soul's check
+	} else if (vars.game_ver == 2) {
+        levelStats = (IntPtr)(0x527298);  // JP check
     }
-	if(validity == 3){
-		levelStats = (IntPtr)(0x51EA18);
-	}
-	validity = 0;
-	for (int i = 0; i < executable.Length; i++){
-      if (executable[i] == jpn[i]) validity++; 
-    }
-	if(validity == 3){
-		levelStats = (IntPtr)(0x527298);
-	}
-	validity = 0;
 	
 	while(lvl > 0) {
-		if(lvl != current.level) {
+		if(lvl != current.level)
 			acc += memory.ReadValue<int>(levelStats + (lvl * 0x2C));
-		}
 		lvl-=1;
 	}
+
 	return TimeSpan.FromSeconds(((acc + current.levelTime) / 30.0));
 }
 


### PR DESCRIPTION
Upon opening Livesplit, Event Viewer reports the following error:
```
Object reference not set to an instance of an object.
at LiveSplit.UI.Components.SplitsComponent.RebuildVisualSplits()
at LiveSplit.UI.LayoutFactories.XMLLayoutFactory.Create(LiveSplitState state)
```
I did not seek out this error as the splitter seemed to be working fine regardless.
The main goal was to find a way to prevent code from being duplicated, which was accomplished by using ASL's built-in `vars` to access a variable outside of the `init` scope.